### PR TITLE
[Feat] 상품 상세 이미지 갤러리(썸네일 선택) 기능 추가

### DIFF
--- a/src/pages/Explore/ui/ProductDetail/index.tsx
+++ b/src/pages/Explore/ui/ProductDetail/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 
+import { ProductGallery } from '@/pages/Explore/ui/ProductDetail/ui/ProductGallery';
 import { RelatedProducts } from '@/pages/Explore/ui/ProductDetail/ui/RelatedProducts';
 import { SERVICE_URLS } from '@/shared/api/endpoints';
 import { addRecentlyViewedProduct } from '@/shared/lib/recentlyViewed';
@@ -82,12 +83,8 @@ const ProductDetail = () => {
     <>
       <div className="w-full flex flex-col">
         <div className="flex gap-6 p-4">
-          <div className="w-[320px] shrink-0 rounded-lg bg-[#f6f6f6] p-4">
-            <img
-              src={product.thumbnail}
-              alt={product.title}
-              className="h-70 w-full rounded-md object-cover"
-            />
+          <div className="w-[320px] shrink-0">
+            <ProductGallery title={product.title} images={product.images} />
           </div>
 
           <div className="flex flex-1 flex-col gap-3">

--- a/src/pages/Explore/ui/ProductDetail/ui/ProductGallery/index.tsx
+++ b/src/pages/Explore/ui/ProductDetail/ui/ProductGallery/index.tsx
@@ -1,0 +1,73 @@
+/**
+ * 만든 이유
+ * - 상품 상세 이미지 영역을 메인 이미지 + 썸네일 선택 구조로 분리한다.
+ * - 이미지 선택 상태를 ProductDetail에서 분리해 책임을 명확히 한다.
+ */
+
+import { useMemo, useState } from 'react';
+
+type ProductGalleryProps = {
+  thumbnail?: string;
+  images?: string[];
+  title: string;
+};
+
+export const ProductGallery = ({ thumbnail, images = [], title }: ProductGalleryProps) => {
+  /**
+   * 초기 메인 이미지 결정 규칙
+   * 1. thumbnail
+   * 2. images[0]
+   * 3. 빈 문자열 (fallback)
+   */
+  const initialImage = useMemo(() => {
+    if (thumbnail) return thumbnail;
+    if (images.length > 0) return images[0];
+    return '';
+  }, [thumbnail, images]);
+
+  const [selectedImage, setSelectedImage] = useState<string>(initialImage);
+
+  // 썸네일 목록 구성 (중복 제거)
+  const thumbnails = useMemo(() => {
+    const list = [...images];
+    if (thumbnail && !list.includes(thumbnail)) {
+      list.unshift(thumbnail);
+    }
+    return list;
+  }, [images, thumbnail]);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex h-50 items-center justify-center rounded-lg bg-[#f6f6f6]">
+        {selectedImage ? (
+          <img
+            src={selectedImage}
+            alt={title}
+            className="h-full w-full rounded-lg object-contain"
+          />
+        ) : (
+          <div className="text-sm text-gray-400">이미지가 없습니다.</div>
+        )}
+      </div>
+
+      {thumbnails.length > 1 && (
+        <div className="flex gap-2 overflow-x-auto">
+          {thumbnails.map((src) => {
+            const isSelected = src === selectedImage;
+
+            return (
+              <button
+                key={src}
+                type="button"
+                onClick={() => setSelectedImage(src)}
+                className={`h-16 w-16 shrink-0 rounded-md border transition ${isSelected ? 'border-black' : 'border-transparent'}`}
+              >
+                <img src={src} alt={title} className="h-full w-full rounded-md object-cover" />
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
## 🔀 PR 제목

[Feat] 상품 상세 이미지 갤러리(썸네일 선택) 기능 추가

---

## 🔗 관련 이슈

> 닫을 이슈를 명시해주세요. (자동 close)

- Close: #124 

---

## ✨ 작업 개요

상품 상세 페이지에 이미지 갤러리 UI를 추가했습니다.

- 메인 이미지 + 썸네일 선택 구조
- 썸네일 클릭 시 메인 이미지 변경
- 이미지 없는 경우 fallback 처리
- ProductGallery 컴포넌트로 책임 분리
 
---

## 📋 변경 사항

- ProductGallery 컴포넌트 추가
- ProductDetail 이미지 영역을 갤러리로 교채
- 초기 이미지 결정 규칙(thumbnail -> images[0]) 적용
- 선택된 썸네일 강조 스타일 적용

---

## ✅ 체크리스트

- [x] npm run ci 통과 (lint, build)
- [x] 썸네일 선택 정상 동작
- [x] 이미지 없는 케이스 fallback 화면

---

## 🧪 테스트 내용 (선택)

- 썸네일 여러 개 상품에서 클릭 시 메인 이미지 변경 확인
- 썸네일 1개/없는 상품에서 UI 깨짐 없는지 확인
- 새로고침/직접 진입 시 초기 이미지 정상 작동 확인

---

## 📸 스크린샷 / 동작 캡처 (선택)

### 변경 전
<img width="878" height="276" alt="스크린샷 2026-01-20 오후 8 09 05" src="https://github.com/user-attachments/assets/d0467957-d562-42a6-af8c-4f408919a1dd" />

### 변경 후
<img width="878" height="276" alt="스크린샷 2026-01-20 오후 8 08 29" src="https://github.com/user-attachments/assets/a4935a30-501c-4999-9964-9dfd39f5b4ba" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Product gallery now displays a browsable thumbnail strip, allowing users to easily view and select different product images.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->