### PR TITLE
[Feat] 상품 상세 이미지 확대 모달(lightbox) 추가 

### DIFF
--- a/src/pages/Explore/ui/ProductDetail/ui/ProductGallery/index.tsx
+++ b/src/pages/Explore/ui/ProductDetail/ui/ProductGallery/index.tsx
@@ -4,7 +4,7 @@
  * - 이미지 선택 상태를 ProductDetail에서 분리해 책임을 명확히 한다.
  */
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 type ProductGalleryProps = {
   thumbnail?: string;
@@ -26,6 +26,7 @@ export const ProductGallery = ({ thumbnail, images = [], title }: ProductGallery
   }, [thumbnail, images]);
 
   const [selectedImage, setSelectedImage] = useState<string>(initialImage);
+  const [isOpen, setIsOpen] = useState<boolean>(false);
 
   // 썸네일 목록 구성 (중복 제거)
   const thumbnails = useMemo(() => {
@@ -36,15 +37,45 @@ export const ProductGallery = ({ thumbnail, images = [], title }: ProductGallery
     return list;
   }, [images, thumbnail]);
 
+  /**
+   * 만든 이유
+   * - 모달이 열려있는 동안 배경 스크롤을 막아 UX를 안정화한다.
+   * - ESC 키로 모달을 닫아 접근성과 사용성을 확보한다.
+   */
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsOpen(false);
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+
+    return () => {
+      document.body.style.overflow = prevOverflow;
+      window.removeEventListener('keydown', onKeyDown);
+    };
+  }, [isOpen]);
+
   return (
     <div className="flex flex-col gap-3">
       <div className="flex h-50 items-center justify-center rounded-lg bg-[#f6f6f6]">
         {selectedImage ? (
-          <img
-            src={selectedImage}
-            alt={title}
-            className="h-full w-full rounded-lg object-contain"
-          />
+          <button
+            type="button"
+            onClick={() => setIsOpen(true)}
+            className="h-full w-full cursor-zoom-in"
+            aria-label="이미지 확대 보기"
+          >
+            <img
+              src={selectedImage}
+              alt={title}
+              className="h-full w-full rounded-lg object-contain"
+            />
+          </button>
         ) : (
           <div className="text-sm text-gray-400">이미지가 없습니다.</div>
         )}
@@ -60,12 +91,42 @@ export const ProductGallery = ({ thumbnail, images = [], title }: ProductGallery
                 key={src}
                 type="button"
                 onClick={() => setSelectedImage(src)}
-                className={`h-16 w-16 shrink-0 rounded-md border transition ${isSelected ? 'border-black' : 'border-transparent'}`}
+                className={`h-16 w-16 shrink-0 rounded-md cursor-pointer border transition ${isSelected ? 'border-black' : 'border-transparent'}`}
               >
                 <img src={src} alt={title} className="h-full w-full rounded-md object-cover" />
               </button>
             );
           })}
+        </div>
+      )}
+
+      {isOpen && selectedImage && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="상품 이미지 확대"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-6"
+          onClick={() => setIsOpen(false)} // 배경 클릭 닫기
+        >
+          <div
+            className="relative max-h-[90vh] max-w-[90vw] rounded-lg bg-white p-3"
+            onClick={(e) => e.stopPropagation()} // 콘텐츠 클릭은 닫히지 않게
+          >
+            <button
+              type="button"
+              onClick={() => setIsOpen(false)}
+              className="absolute right-2 top-2 rounded-md px-2 py-1 text-sm cursor-pointer"
+              aria-label="닫기"
+            >
+              닫기
+            </button>
+
+            <img
+              src={selectedImage}
+              alt={title}
+              className="max-h-[80vh] max-w-[85vw] rounded-md object-contain"
+            />
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## 🔀 PR 제목

[Feat] 상품 상세 이미지 확대 모달(lightbox) 추가

---

## 🔗 관련 이슈

> 닫을 이슈를 명시해주세요. (자동 close)

- Close: #126 

---

## ✨ 작업 개요

상품 상세 이미지에 확애 모달(lightbox)을 추가했습니다.

- 메인 이미지 클릭 시 모달 오픈
- 배경 클릭 / ESC 키로 닫기
- 모달 오픈 시 body 스크롤 lock 처리
- ProductGallery 내부에서 상태 / 책임 관리

---

## 📋 변경 사항

- ProductGallery에 이미지 확대 모달 기능 추가
- ESC 키 이벤트 처리 및 접근성(role/aria) 적용
- 배경 스크롤 잠금으로 UX 안정화

---

## ✅ 체크리스트

- [x] npm run ci 통과 (lint, build)
- [x] ESC / 배경 클릭 정상 동작
- [x] 스크롤 lock 정상 동작

---

## 🧪 테스트 내용 (선택)

- 메인 이미지 클릭 -> 모달 열람
- 배경 클릭 / ESC -> 닫힘
- 모달 열린 상태에서 배경 스크롤 불가 확인
- 썸네일 변경 후 확대 이미지 정상 반영 확인

---

## 📸 스크린샷 / 동작 캡처 (선택)

https://github.com/user-attachments/assets/f490a08b-b2a9-40df-bd00-5d822c9a6b23

