### PR TITLE
[Refactor] 상품 상세 정보 레이아웃 및 시각적 위계 개선

### DIFF
--- a/src/pages/Explore/ui/ProductDetail/index.tsx
+++ b/src/pages/Explore/ui/ProductDetail/index.tsx
@@ -87,20 +87,58 @@ const ProductDetail = () => {
             <ProductGallery title={product.title} images={product.images} />
           </div>
 
-          <div className="flex flex-1 flex-col gap-3">
+          <div className="flex flex-1 flex-col">
             <div className="text-2xl font-semibold">{product.title}</div>
 
-            <div className="flex items-center gap-3 text-sm text-gray-600">
+            <section className="mb-2">
+              <div className="flex items-end gap-2">
+                <span className="text-2xl font-bold text-black">
+                  $ {product.price.toLocaleString()}
+                </span>
+                {product.discountPercentage > 0 && (
+                  <div className="mt-1 text-sm text-gray-400 line-through">
+                    $
+                    {Math.round(
+                      product.price / (1 - product.discountPercentage / 100),
+                    ).toLocaleString()}
+                  </div>
+                )}
+
+                {product.discountPercentage > 0 && (
+                  <span className="text-sm text-red-500">{product.discountPercentage}% 할인</span>
+                )}
+              </div>
+            </section>
+
+            <section className="mb-6 space-y-1 text-sm text-gray-600">
+              <div>⭐ 평점 {product.rating}</div>
               <div>카테고리: {product.category}</div>
-              <div>평점: {product.rating}</div>
-            </div>
+              <div>
+                재고: {''}
+                <span className={product.stock > 0 ? 'text-green-600' : 'text-red-500'}>
+                  {product.stock > 0 ? `${product.stock}개 남음` : '품절'}
+                </span>
+              </div>
+            </section>
 
-            <div className="flex items-end gap-3">
-              <div className="text-3xl font-bold">$ {product.price}</div>
-              <div className="text-sm text-gray-600">할인율 {product.discountPercentage}%</div>
-            </div>
+            <section className="mb-6 text-sm leading-relaxed text-gray-700">
+              {product.description}
+            </section>
 
-            <div className="mt-2 text-sm leading-6 text-gray-700">{product.description}</div>
+            <section className="flex gap-3">
+              <button
+                type="button"
+                className="flex-1 rounded-md border border-black px-4 py-2 text-sm cursor-pointer"
+              >
+                장바구니
+              </button>
+              <button
+                type="button"
+                className="flex-1 rounded-md bg-black px-4 py-2 text-sm text-white cursor-pointer"
+              >
+                구매하기
+              </button>
+            </section>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 🔀 PR 제목

[Refactor] 상품 상세 정보 레이아웃 및 시각적 위계 개선

---

## 🔗 관련 이슈

- Close: #127 

---

## ✨ 작업 개요

상품 상세 페이지의 정보 구조와 시각적 위계를 개선했습니다.

- 가격/할인율/원가 표시를 정리해 가독성 개선
- 평점/카테고리/재고를 보조 정보 블록으로 분리
- CTA(장바구니/구매하기) 영역 추가로 상세 완성도 향상
- 설명 영역 가독성 개선

---

## 📋 변경 사항

- ProductDetail 우측 정보 영역을 블록 단위로 재구성(Price / Meta / CTA / Description)
- 할인 상품 / 비할인 상품 UI 분기 정리
- 재고 상태 텍스트 색상 처리로 인지성 향상

---

## ✅ 체크리스트

- [x] npm run ci 통과 (lint, build)
- [x] 상세 정보 가독성/위계 개선 확인

---

## 🧪 테스트 내용 (선택)

- /explore/:id 진입 후 가격/할인율/원가 표시 확인
- 재고 (stock) 0/양수 케이스 텍스트 색상 확인
- 버튼 레이아웃 및 반응 확인

---

## 📸 스크린샷 / 동작 캡처 (선택)

### 구현 전
<img width="914" height="264" alt="스크린샷 2026-01-20 오후 9 55 00" src="https://github.com/user-attachments/assets/d999b897-cd64-47d8-ac3d-6f5140f0889f" />

### 구현 후
<img width="914" height="264" alt="스크린샷 2026-01-20 오후 9 54 49" src="https://github.com/user-attachments/assets/29f50125-c850-447b-a97f-514bc1d9d2fe" />