### PR TITLE
[Feat] 장바구니 페이지 UI 및 리스트 렌더 추가

### DIFF
--- a/src/app/routes/index.tsx
+++ b/src/app/routes/index.tsx
@@ -1,5 +1,6 @@
 import { Route, Routes } from 'react-router-dom';
 
+import Cart from '@/pages/Cart';
 import Explore from '@/pages/Explore';
 import ProductDetail from '@/pages/Explore/ui/ProductDetail';
 import Layout from '@/pages/Layout';
@@ -33,6 +34,7 @@ const AppRoutes = () => {
           <Route path=":id" element={<ProductDetail />} />
         </Route>
         <Route path="/recipes" element={<Explore />} />
+        <Route path="/cart" element={<Cart />} />
         <Route path="/search" element={<SearchProducts />} />
         <Route path="/selectUser" element={<SelectUser />} />
         <Route path={`/${userInfo?.username}`} element={<MyPage />} />

--- a/src/pages/Cart/index.tsx
+++ b/src/pages/Cart/index.tsx
@@ -1,0 +1,31 @@
+/**
+ * 만든 이유
+ * - 장바구니 페이지의 진입점
+ * - sessionStorage에 저장된 cartItems를 조회해 목록/빈 상태를 렌더한다.
+ */
+
+import CartItemRow from '@/pages/Cart/ui/CartItemRow';
+import { getCartItems } from '@/shared/lib/cart';
+import { EmptyState } from '@/shared/ui';
+
+const Cart = () => {
+  const cartItems = getCartItems();
+
+  if (cartItems.length === 0) {
+    return <EmptyState title="장바구니가 비어 있어요" description="상품을 담아보세요." />;
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-6">
+      <h1 className="mb-6 text-xl font-semibold">장바구니</h1>
+
+      <div className="space-y-4">
+        {cartItems.map((item) => (
+          <CartItemRow key={item.id} item={item} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Cart;

--- a/src/pages/Cart/ui/CartItemRow.tsx
+++ b/src/pages/Cart/ui/CartItemRow.tsx
@@ -1,0 +1,31 @@
+/**
+ * 만든 이유
+ * - 장바구니 상품 한 줄(Row)을 담당
+ * - Day3에서 수량 변경 / 삭제 로직을 이 컴포넌트 기준으로 확장한다.
+ */
+
+import { CartItem } from '@/shared/types/response';
+
+type Props = { item: CartItem };
+
+const CartItemRow = ({ item }: Props) => {
+  return (
+    <div className="flex items-center gap-4 rounded-md border p-4">
+      <img
+        src={item.thumbnail}
+        alt={item.title}
+        className="h-16 w-16 rounded object-cover"
+        loading="lazy"
+      />
+
+      <div className="flex-1">
+        <div className="font-medium">{item.title}</div>
+        <div className="text-sm text-gray-500">₩{item.price.toLocaleString()}</div>
+      </div>
+
+      <div className="text-sm">수량 {item.quantity}</div>
+    </div>
+  );
+};
+
+export default CartItemRow;


### PR DESCRIPTION
## 🔀 PR 제목

[Feat] 장바구니 페이지 UI 및 리스트 렌더 추가

---

## 🔗 관련 이슈

> 닫을 이슈를 명시해주세요. (자동 close)

- Close: #134 

---

## ✨ 작업 개요

장바구니 페이지(`/cart`)를 추가하고, sessionStorage에 저장된 cartItems를 기반으로 리스트 UI를 구현했습니다.

- 장바구니 페이지 라우트 추가
- 장바구니 상품 리스트 렌더
- 장바구니가 비어 있을 경우 EmptyState 처리
- 수량 변경 / 삭제를 위한 Row 컴포넌트 분리

---

## 관련 작업
- 장바구니 페이지 진입 경로 (`/cart`) 추가
- Cart 페이지에서 cartItems 조회 및 조건부 렌더
- CartItemRow 컴포넌트로 행 단위 UI 분리

## 📋 변경 사항

- `/cart` 라우트 추가
- `Cart/index.ts` 컴포넌트 추가
- 장바구니 비어 있을 경우 EmptyState 노출

---

## ✅ 체크리스트

- [ ] `cart` 직접 진입 시 페이지 노출 확인
- [ ] cartItems가 없을 때 EmptyState 표시 확인
- [ ] 상품 닫은 뒤 `/cart` 이동 시 리스트 렌더 확인
- [ ] 새로고침 후에도 동일한 장바구니 상태 유지 확인

---

## 📸 스크린샷 / 동작 캡처 (선택)

### 담은 상품이 없을 경우
<img width="364" height="74" alt="스크린샷 2026-01-27 오후 5 02 13" src="https://github.com/user-attachments/assets/baad34e1-e25a-4d61-84e1-c3465d3d00d6" />

### 담은 상품이 있을 경우
<img width="364" height="342" alt="스크린샷 2026-01-27 오후 5 01 34" src="https://github.com/user-attachments/assets/86f7b595-5afe-47ef-85e7-e228dce96f63" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new cart page accessible via the /cart route
  * Displays all items currently in your cart with detailed product information
  * Shows an empty state message when your cart contains no items
  * Each cart item displays the product thumbnail, title, price formatted to your locale, and quantity

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->