### PR TITLE
[Feat] 장바구니 수량 변경/삭제 및 합계 계산 추가

### DIFF
--- a/src/pages/Cart/index.tsx
+++ b/src/pages/Cart/index.tsx
@@ -4,12 +4,27 @@
  * - sessionStorage에 저장된 cartItems를 조회해 목록/빈 상태를 렌더한다.
  */
 
+import { useMemo, useState } from 'react';
+
 import CartItemRow from '@/pages/Cart/ui/CartItemRow';
 import { getCartItems } from '@/shared/lib/cart';
 import { EmptyState } from '@/shared/ui';
 
 const Cart = () => {
-  const cartItems = getCartItems();
+  const [cartItems, setCartItems] = useState(() => getCartItems());
+
+  /**
+   * 만든 이유
+   * - cart 유틸은 sessionStorage를 변경하지만, React는 storage 변경을 자동으로 감지하니 않는다.
+   * - 따라서 액션 이후 최신 값을 다시 읽어 state를 갱신한다.
+   */
+  const refreshCart = () => setCartItems(getCartItems());
+
+  const summary = useMemo(() => {
+    const totalQuantity = cartItems.reduce((acc, cur) => acc + cur.quantity, 0);
+    const totalPrice = cartItems.reduce((acc, cur) => acc + cur.price * cur.quantity, 0);
+    return { totalQuantity, totalPrice };
+  }, [cartItems]);
 
   if (cartItems.length === 0) {
     return <EmptyState title="장바구니가 비어 있어요" description="상품을 담아보세요." />;
@@ -21,8 +36,20 @@ const Cart = () => {
 
       <div className="space-y-4">
         {cartItems.map((item) => (
-          <CartItemRow key={item.id} item={item} />
+          <CartItemRow key={item.id} item={item} onChange={refreshCart} />
         ))}
+      </div>
+
+      <div className="mt-6 rounded-md border p-4">
+        <div className="flex justify-between text-sm">
+          <span className="text-gray-600">총 수량</span>
+          <span className="font-medium">{summary.totalQuantity}개</span>
+        </div>
+
+        <div className="mt-2 flex justify-between text-sm">
+          <span className="text-gray-600">총 금액</span>
+          <span className="font-semibold">$ {summary.totalPrice}</span>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/Cart/ui/CartItemRow.tsx
+++ b/src/pages/Cart/ui/CartItemRow.tsx
@@ -4,11 +4,12 @@
  * - Day3에서 수량 변경 / 삭제 로직을 이 컴포넌트 기준으로 확장한다.
  */
 
+import { removeFromCart, updateCartQuantity } from '@/shared/lib/cart';
 import { CartItem } from '@/shared/types/response';
 
-type Props = { item: CartItem };
+type Props = { item: CartItem; onChange: () => void };
 
-const CartItemRow = ({ item }: Props) => {
+const CartItemRow = ({ item, onChange }: Props) => {
   return (
     <div className="flex items-center gap-4 rounded-md border p-4">
       <img
@@ -20,10 +21,47 @@ const CartItemRow = ({ item }: Props) => {
 
       <div className="flex-1">
         <div className="font-medium">{item.title}</div>
-        <div className="text-sm text-gray-500">₩{item.price.toLocaleString()}</div>
+        <div className="text-sm text-gray-500">$ {item.price.toLocaleString()}</div>
       </div>
 
-      <div className="text-sm">수량 {item.quantity}</div>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          className="h-8 w-8 rounded border  cursor-pointer"
+          onClick={() => {
+            updateCartQuantity(item.id, item.quantity - 1);
+            onChange();
+          }}
+          disabled={item.quantity <= 1}
+        >
+          -
+        </button>
+
+        <div className="w-10 text-center text-sm">{item.quantity}</div>
+
+        <button
+          type="button"
+          className="h-8 w-8 rounded border  cursor-pointer"
+          onClick={() => {
+            updateCartQuantity(item.id, item.quantity + 1);
+            onChange();
+          }}
+          disabled={item.quantity >= item.stock}
+        >
+          +
+        </button>
+      </div>
+
+      <button
+        type="button"
+        className="ml-3 text-sm text-red-500 cursor-pointer"
+        onClick={() => {
+          removeFromCart(item.id);
+          onChange();
+        }}
+      >
+        삭제
+      </button>
     </div>
   );
 };

--- a/src/shared/lib/cart.ts
+++ b/src/shared/lib/cart.ts
@@ -47,3 +47,44 @@ export const addToCart = (item: Omit<CartItem, 'quantity'>) => {
 
   setCartItems(next);
 };
+
+/**
+ * 만든 이유
+ * - 장바구니 수량 변경을 단일 함수로 통제한다.
+ * - 최소 1, 최대 stock 정책을 여기서 강제한다.
+ */
+export const updateCartQuantity = (id: number, nextQuantity: number) => {
+  const current = getCartItems();
+
+  const next = current.map((c) => {
+    if (c.id !== id) return c;
+
+    const clamped = Math.min(Math.max(nextQuantity, 1), c.stock);
+    return { ...c, quantity: clamped };
+  });
+
+  setCartItems(next);
+};
+
+/**
+ * 만든 이유
+ * - 장바구니에서 특정 상품을 제거한다.
+ */
+export const removeFromCart = (id: number) => {
+  const current = getCartItems();
+  setCartItems(current.filter((c) => c.id !== id));
+};
+
+/**
+ * 만든 이유
+ * - UI에서 합계를 매번 계산하지 않도록 도메인 유틸로 분리한다.
+ * - 총 수량/총 금액을 한 번에 계산해준다.
+ */
+export const getCartSummary = () => {
+  const items = getCartItems();
+
+  const totalQuantity = items.reduce((acc, cur) => acc + cur.quantity, 0);
+  const totalPrice = items.reduce((acc, cur) => acc + cur.price * cur.quantity, 0);
+
+  return { totalQuantity, totalPrice };
+};


### PR DESCRIPTION
## 🔀 PR 제목

[Feat] 장바구니 수량 변경/삭제 및 합계 계산 추가

---

## 🔗 관련 이슈

> 닫을 이슈를 명시해주세요. (자동 close)

- Close: #136 

---

## ✨ 작업 개요

장바구니 페이지에서 수량 변경(+/-), 삭제, 합계(총 수량/총 금액) 기능을 추가했습니다.

- + / - 버튼으로 수량 변경
- 최소 1, 최대 stock 이하 정책 적용
- 개별 상품 삭제
- 총 수량 / 총 금액 합계 영역 추가
-  변경 사항 sessionStorage 반영

---

## 📋 변경 사항

- cart 유틸 확장
  - updateCartQuantity 
  - removeFromCart
  - getCartSummary (또는 합계 계산 로직)
- Cart 페이지에서 cartItems를 state로 관리하고 액션 후 refresh
- CartItemRow에 수량 변경 / 삭제 UI 추가 및 disabled 처리 

---

## ✅ 체크리스트

- [x] 수량 정책 정상 동작(1~stock)
- [x] 삭제 정상 동작
- [x] 합계 갱신 정상
- [x] sessionStorage 반영/유지 정상

---

## 🧪 테스트 내용 (선택)

- /cart 진입 후 +/- 클릭 시 수량 즉시 반영 확인
- 수량이 1 미만으로 내려가지 않는지 확인
- 수량이 stock을 초과하지 않는지 확인
- 삭제 버튼 클릭 시 아이템 제거 확인
- 합계 (총 수량 / 총 금액)가 즉시 갱신되는지 확인
- 새로고침 후에도 유지되는지 확인

---

## 📸 스크린샷 / 동작 캡처 (선택)

<img width="364" height="324" alt="스크린샷 2026-01-27 오후 5 55 16" src="https://github.com/user-attachments/assets/ab9a516f-bacf-4c0e-a61f-5a528e96ff60" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added quantity adjustment controls (increment/decrement buttons) for individual cart items with stock limits
  * Added delete functionality to remove items from cart
  * Added cart summary section displaying total quantity and total price

* **UI Changes**
  * Updated currency format to USD ($)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->