### PR TITLE
[UX] 장바구니 UX 개선 (토스트/재고 안내/삭제 확인)

### DIFF
--- a/src/pages/Cart/ui/CartItemRow.tsx
+++ b/src/pages/Cart/ui/CartItemRow.tsx
@@ -12,8 +12,8 @@ type Props = { item: CartItem; onChange: () => void };
 const CartItemRow = ({ item, onChange }: Props) => {
   const isStockLimit = item.quantity >= item.stock;
   return (
-    <>
-      <div className="flex items-center gap-4 rounded-md border p-4">
+    <div className="flex flex-col  rounded-md border p-4 gap-2">
+      <div className="flex items-center">
         <img
           src={item.thumbnail}
           alt={item.title}
@@ -58,15 +58,17 @@ const CartItemRow = ({ item, onChange }: Props) => {
           type="button"
           className="ml-3 text-sm text-red-500 cursor-pointer"
           onClick={() => {
-            removeFromCart(item.id);
-            onChange();
+            if (confirm('정말 이 상품을 장바구니에서 삭제할까요?')) {
+              removeFromCart(item.id);
+              onChange();
+            }
           }}
         >
           삭제
         </button>
       </div>
       {isStockLimit && <div className="text-orange-500 text-xs">재고 한도에 도달했어요.</div>}
-    </>
+    </div>
   );
 };
 

--- a/src/pages/Cart/ui/CartItemRow.tsx
+++ b/src/pages/Cart/ui/CartItemRow.tsx
@@ -10,59 +10,63 @@ import { CartItem } from '@/shared/types/response';
 type Props = { item: CartItem; onChange: () => void };
 
 const CartItemRow = ({ item, onChange }: Props) => {
+  const isStockLimit = item.quantity >= item.stock;
   return (
-    <div className="flex items-center gap-4 rounded-md border p-4">
-      <img
-        src={item.thumbnail}
-        alt={item.title}
-        className="h-16 w-16 rounded object-cover"
-        loading="lazy"
-      />
+    <>
+      <div className="flex items-center gap-4 rounded-md border p-4">
+        <img
+          src={item.thumbnail}
+          alt={item.title}
+          className="h-16 w-16 rounded object-cover"
+          loading="lazy"
+        />
 
-      <div className="flex-1">
-        <div className="font-medium">{item.title}</div>
-        <div className="text-sm text-gray-500">$ {item.price.toLocaleString()}</div>
-      </div>
+        <div className="flex-1">
+          <div className="font-medium">{item.title}</div>
+          <div className="text-sm text-gray-500">$ {item.price.toLocaleString()}</div>
+        </div>
 
-      <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            className="h-8 w-8 rounded border cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+            onClick={() => {
+              updateCartQuantity(item.id, item.quantity - 1);
+              onChange();
+            }}
+            disabled={item.quantity <= 1}
+          >
+            -
+          </button>
+
+          <div className="w-10 text-center text-sm">{item.quantity}</div>
+
+          <button
+            type="button"
+            className="h-8 w-8 rounded border cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+            onClick={() => {
+              updateCartQuantity(item.id, item.quantity + 1);
+              onChange();
+            }}
+            disabled={item.quantity >= item.stock}
+          >
+            +
+          </button>
+        </div>
+
         <button
           type="button"
-          className="h-8 w-8 rounded border  cursor-pointer"
+          className="ml-3 text-sm text-red-500 cursor-pointer"
           onClick={() => {
-            updateCartQuantity(item.id, item.quantity - 1);
+            removeFromCart(item.id);
             onChange();
           }}
-          disabled={item.quantity <= 1}
         >
-          -
-        </button>
-
-        <div className="w-10 text-center text-sm">{item.quantity}</div>
-
-        <button
-          type="button"
-          className="h-8 w-8 rounded border  cursor-pointer"
-          onClick={() => {
-            updateCartQuantity(item.id, item.quantity + 1);
-            onChange();
-          }}
-          disabled={item.quantity >= item.stock}
-        >
-          +
+          삭제
         </button>
       </div>
-
-      <button
-        type="button"
-        className="ml-3 text-sm text-red-500 cursor-pointer"
-        onClick={() => {
-          removeFromCart(item.id);
-          onChange();
-        }}
-      >
-        삭제
-      </button>
-    </div>
+      {isStockLimit && <div className="text-orange-500 text-xs">재고 한도에 도달했어요.</div>}
+    </>
   );
 };
 

--- a/src/pages/Explore/ui/ProductDetail/index.tsx
+++ b/src/pages/Explore/ui/ProductDetail/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { ProductGallery } from '@/pages/Explore/ui/ProductDetail/ui/ProductGallery';
@@ -10,6 +10,7 @@ import { QUERY_KEYS } from '@/shared/query/key';
 import { useFetchQuery } from '@/shared/query/useFetchQuery';
 import type { Product } from '@/shared/types/response';
 import { EmptyState, ErrorState, SkeletonBox } from '@/shared/ui';
+import Toast from '@/shared/ui/Toast';
 
 /**
  * 만든 이유
@@ -18,6 +19,7 @@ import { EmptyState, ErrorState, SkeletonBox } from '@/shared/ui';
  */
 const ProductDetail = () => {
   const params = useParams();
+  const [showToast, setShowToast] = useState(false);
 
   // params.id는 string | undefined 이므로 number로 안전변환
   const productId = useMemo(() => {
@@ -33,6 +35,10 @@ const ProductDetail = () => {
       thumbnail: String(product?.thumbnail),
       stock: Number(product?.stock),
     });
+
+    setTimeout(() => {
+      setShowToast(true);
+    }, 2000);
   };
 
   const {
@@ -155,6 +161,7 @@ const ProductDetail = () => {
           </div>
         </div>
       </div>
+      {showToast && <Toast message="장바구니에 담겼습니다." />}
 
       <RelatedProducts category={product.category} currentProductId={productId} />
     </>

--- a/src/shared/ui/ProductItem/index.tsx
+++ b/src/shared/ui/ProductItem/index.tsx
@@ -13,17 +13,19 @@ import { calculateOriginalPrice } from '@/shared/lib';
 import { addToCart } from '@/shared/lib/cart';
 import { QUERY_KEYS } from '@/shared/query/key';
 import type { Product } from '@/shared/types/response';
+import Toast from '@/shared/ui/Toast';
 
 type ProductItemProps = Partial<Product> & {
   isLoading?: boolean;
 };
 
 const ProductItem = (pr: ProductItemProps) => {
+  const [showToast, setShowToast] = useState(false);
+  const [toggle, setToggle] = useState(false);
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const location = useLocation();
   const queryClient = useQueryClient();
-  const [toggle, setToggle] = useState(false);
   const { ref } = useIntersectionObserver();
 
   const handleAddToCart = () => {
@@ -37,7 +39,11 @@ const ProductItem = (pr: ProductItemProps) => {
       stock: Number(pr.stock),
     });
 
-    setToggle((prev) => !prev);
+    setToggle(true);
+
+    setTimeout(() => {
+      setShowToast(true);
+    }, 2000);
   };
 
   /**
@@ -134,6 +140,7 @@ const ProductItem = (pr: ProductItemProps) => {
           Detail
         </button>
       </div>
+      {showToast && <Toast message="장바구니에 담겼어요" />}
     </div>
   );
 };

--- a/src/shared/ui/Toast/index.tsx
+++ b/src/shared/ui/Toast/index.tsx
@@ -1,0 +1,17 @@
+/**
+ * 만든 이유
+ * - 사용자 액션(담기 완료)에 대한 즉각적인 피드백 제공
+ * - 공통 UI로 분리해 여러 화면에서 재사용 가능하게 한다.
+ */
+
+type Props = { message: string };
+
+const Toast = ({ message }: Props) => {
+  return (
+    <div className="fixed bottom-6 right-6 z-50 rounded-md bg-black px-4 py-2 text-sm text-white shadow">
+      {message}
+    </div>
+  );
+};
+
+export default Toast;


### PR DESCRIPTION
## 🔀 PR 제목

[UX] 장바구니 UX 개선 (토스트/재고 안내/삭제 확인)

---

## 🔗 관련 이슈

> 닫을 이슈를 명시해주세요. (자동 close)

- Close: #138 

---

## ✨ 작업 개요

장바구니 관련 UX를 개선했습니다. 

- 장바구니 담기 성공 시 Toast 피드백 추가
- 수량이 재고 (stock) 한도에 도달했을 때 안내 문구 노출
- 수량 증가/감소 버튼 disabled 상태 시각적 피드백 강화
- 장바구니 상품 삭제 시 확인(confirm) UX 추가

---

## 📋 변경 사항

- Toast 공통 UI 컴포넌트 추가 및 목록/상세 담기 흐름에 연결
- CartItemRow에서 재고 한도 도달 시 안내 문구 표시
- disabled 버튼 스타일(opacity/cursor)로 상태 명확화
- 삭제 버튼 클릭 시 confirm 이후에만 remove + refresh 수행

---

## ✅ 체크리스트

- [x] UX 변경이 기존 장바구니 기능에 영향 없음
- [x] build/린트 에러 없음

---

## 🧪 테스트 내용 (선택)

- 상품 목록/상세에서 장바구니 담기 -> Toast 노출 확인
- /cart에서 수량을 stock까지 올린 뒤 + 버튼 disabled 및 안내 문구 노출 확인
  - 버튼이 1에서 disabled 되는지 확인
- 삭제 버튼 클릭 시 확인 창에서 취소/확인 동작 확인
- 새로고침 후에도 상태 유지 확인

---

## 📸 스크린샷 / 동작 캡처 (선택)

### 수량 + / - 클릭 시
https://github.com/user-attachments/assets/989745c6-94fc-49be-a83a-01a0382d3718

### 삭제 버튼 클릭 시
https://github.com/user-attachments/assets/672e95bd-e16d-4dd4-8323-7940e69941ff




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stock limit controls with increment/decrement buttons in cart items
  * Introduced cart item deletion confirmation prompt
  * Added toast notifications confirming items added to cart
  * Stock limit reached message displays when inventory maximum is reached

* **UI/UX Improvements**
  * Improved cart item row layout with better visual structure
  * Button states now reflect disabled state when stock or quantity limits apply

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->