### PR TITLE
[Refactor] 공통 토스트 훅(useToast) 도입 및 담기 UX 안정화

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,6 +15,7 @@ import { QueryProvider, ScrollToTop } from '@/app/provider';
 
 import AppRouter from '@/app/routes';
 import { store } from '@/app/store';
+import ToastRender from '@/shared/ui/Toast/ToastRender';
 
 const container = document.getElementById('root');
 
@@ -29,6 +30,7 @@ createRoot(container).render(
         <ScrollToTop />
         <Provider store={store}>
           <AppRouter />
+          <ToastRender />
         </Provider>
       </BrowserRouter>
     </QueryProvider>

--- a/src/pages/Explore/ui/ProductDetail/index.tsx
+++ b/src/pages/Explore/ui/ProductDetail/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { ProductGallery } from '@/pages/Explore/ui/ProductDetail/ui/ProductGallery';
@@ -10,7 +10,7 @@ import { QUERY_KEYS } from '@/shared/query/key';
 import { useFetchQuery } from '@/shared/query/useFetchQuery';
 import type { Product } from '@/shared/types';
 import { EmptyState, ErrorState, SkeletonBox } from '@/shared/ui';
-import Toast from '@/shared/ui/Toast';
+import { useToast } from '@/shared/ui/Toast/useToast';
 
 /**
  * 만든 이유
@@ -18,8 +18,8 @@ import Toast from '@/shared/ui/Toast';
  * - Week2에서 만든 공통 상태 UI(Skeleton/Error/Empty)를 그대호 사용해 로딩/에러 UX를 일관되게 유지한다.
  */
 const ProductDetail = () => {
+  const { showToast } = useToast();
   const params = useParams();
-  const [showToast, setShowToast] = useState(false);
 
   // params.id는 string | undefined 이므로 number로 안전변환
   const productId = useMemo(() => {
@@ -36,9 +36,7 @@ const ProductDetail = () => {
       stock: Number(product?.stock),
     });
 
-    setTimeout(() => {
-      setShowToast(true);
-    }, 2000);
+    showToast('장바구니에 담겼어요.');
   };
 
   const {
@@ -161,7 +159,6 @@ const ProductDetail = () => {
           </div>
         </div>
       </div>
-      {showToast && <Toast message="장바구니에 담겼습니다." />}
 
       <RelatedProducts category={product.category} currentProductId={productId} />
     </>

--- a/src/shared/ui/ProductItem/index.tsx
+++ b/src/shared/ui/ProductItem/index.tsx
@@ -13,14 +13,14 @@ import { calculateOriginalPrice } from '@/shared/lib';
 import { addToCart } from '@/shared/lib/cart';
 import { QUERY_KEYS } from '@/shared/query/key';
 import type { Product } from '@/shared/types';
-import Toast from '@/shared/ui/Toast';
+import { useToast } from '@/shared/ui/Toast/useToast';
 
 type ProductItemProps = Partial<Product> & {
   isLoading?: boolean;
 };
 
 const ProductItem = (pr: ProductItemProps) => {
-  const [showToast, setShowToast] = useState(false);
+  const { showToast } = useToast();
   const [toggle, setToggle] = useState(false);
   const dispatch = useDispatch();
   const navigate = useNavigate();
@@ -41,9 +41,7 @@ const ProductItem = (pr: ProductItemProps) => {
 
     setToggle(true);
 
-    setTimeout(() => {
-      setShowToast(true);
-    }, 2000);
+    showToast('장바구니에 담겼어요.');
   };
 
   /**
@@ -140,7 +138,6 @@ const ProductItem = (pr: ProductItemProps) => {
           Detail
         </button>
       </div>
-      {showToast && <Toast message="장바구니에 담겼어요" />}
     </div>
   );
 };

--- a/src/shared/ui/Toast/ToastRender.tsx
+++ b/src/shared/ui/Toast/ToastRender.tsx
@@ -1,0 +1,20 @@
+/**
+ * 만든 이유
+ * - React가 toastStore(외부 상태)를 구독하도록 연결하는 렌더러다.
+ * - 앱 전체에서 단 1번(main.tsx)만 렌더되어야 한다.
+ */
+
+import { useSyncExternalStore } from 'react';
+
+import Toast from '@/shared/ui/Toast';
+import { toastStore } from '@/shared/ui/Toast/toastStore';
+
+const ToastRender = () => {
+  const toastState = useSyncExternalStore(toastStore.subscribe, toastStore.getSnapshot);
+
+  if (!toastState.visible) return null;
+
+  return <Toast message={toastState.message} />;
+};
+
+export default ToastRender;

--- a/src/shared/ui/Toast/toastStore.ts
+++ b/src/shared/ui/Toast/toastStore.ts
@@ -1,0 +1,63 @@
+/**
+ * 만든 이유
+ * - Toast 전역 상태(visible/message)와 타이머를 "모듈 싱글톤"으로 관리한다.
+ * - subscribe/emit 패턴으로 React(ToastRender)가 상태 변경을 구독할 수 있게 된다.
+ */
+
+export type ToastState = {
+  visible: boolean;
+  message: string;
+};
+
+type Listener = () => void;
+
+let state: ToastState = { visible: false, message: '' };
+let timeoutId: number | null = null;
+
+const listeners = new Set<Listener>();
+
+const emit = () => {
+  listeners.forEach((listeners) => listeners());
+};
+
+const getSnapshot = (): ToastState => state;
+
+const subscribe = (listener: Listener) => {
+  listeners.add(listener);
+
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+const hide = () => {
+  if (timeoutId !== null) {
+    window.clearTimeout(timeoutId);
+    timeoutId = null;
+  }
+
+  state = { ...state, visible: false };
+  emit();
+};
+
+const show = (message: string, durationMs: number = 2000) => {
+  // 연타 안정화: 이전 타이머가 있으면 끊고 새로 시작
+  if (timeoutId !== null) {
+    window.clearTimeout(timeoutId);
+    timeoutId = null;
+  }
+
+  state = { visible: true, message };
+  emit();
+
+  timeoutId = window.setTimeout(() => {
+    hide();
+  }, durationMs);
+};
+
+export const toastStore = {
+  getSnapshot,
+  subscribe,
+  show,
+  hide,
+};

--- a/src/shared/ui/Toast/useToast.ts
+++ b/src/shared/ui/Toast/useToast.ts
@@ -1,0 +1,19 @@
+/**
+ * 만든 이유
+ * - 컴포넌트들은 Toast의 내부 상태/타이머를 몰라도 된다.
+ * - showToast(message) 한 줄로 전역 Toast를 띄우는 "명령 API"만 제공한다.
+ */
+
+import { toastStore } from '@/shared/ui/Toast/toastStore';
+
+export const useToast = () => {
+  const showToast = (message: string, durationMs?: number) => {
+    toastStore.show(message, durationMs);
+  };
+
+  const hideToast = () => {
+    toastStore.hide();
+  };
+
+  return { showToast, hideToast };
+};


### PR DESCRIPTION
## 🔀 PR 제목

[Refactor] 공통 토스트 훅(useToast) 도입 및 담기 UX 안정화

---

## 🔗 관련 이슈

> 닫을 이슈를 명시해주세요. (자동 close)

- Close: #141 

---

## ✨ 작업 개요

전역 Toast를 모듈 스토어 기반으로 표준화하고, 페이지별 중복 타이머 로직을 제거했습니다. 

---

## 📋 변경 사항

- `shared/ui/Toast/toastStore.ts`
  - Toast 전역 상태 및 타이머 관리(모듈 싱글톤)
- `shared/ui/Toast/useToast.ts` 
  - showToast/hideToast 명령 API 제공
- `shared/ui/Toast/ToastRender.ts`
  - useSyncExternalStore 기반 외부 스토어 구독 렌더러
- `main.tsx`
  - ToastRender를 앱 전역에 1회 렌더
- ProductItem / ProductDetail
  - 로컬 useState + setTimeout 제거
  - showToast 호출로 통일    

---

## ✅ 체크리스트

- [x] Toast가 앱에서 1개만 렌더됨
- [x] 중복 타이머 로직 제거
- [x] 연타 안정화 적용
- [x] build/린트 에러 없음

---

## 🧪 테스트 내용 (선택)

- 상품 목록에서 장바구니 담기 -> Toast 노출 확인
- 상품 상세에서 장바구니 담기 -> Toast 노출 확인
- 연속 클릭(연타) 시 Toast가 자연스럽게 유지되는지 확인
- 라우트 이동 후에도 Toast가 정상 동작하는지 확인

---

## 📸 스크린샷 / 동작 캡처 (선택)

### 구현 전 - 토스트가 계속 겹치는 현상, 꺼지지 않는 현상이 발생

https://github.com/user-attachments/assets/41414d91-07d9-4fda-92b3-001b46fa5c37

### 구현 후 - 토스트가 정상적으로 작동하고 마지막 클릭 기준으로 타이머가 돈다.

https://github.com/user-attachments/assets/b6160bad-9d54-4e09-8ef0-ff465a81fe46




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the internal notification system used when adding items to cart, ensuring consistent and reliable message delivery across the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->